### PR TITLE
remove 'traffic' reference

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -6,7 +6,6 @@
   pages = {231--239},
   editor = {Bruce Christianson and James A. Malcolm and Vashek Maty\'{a}\v{s} and Michael Roe},
   year = 2013,
-  www_section = traffic,
   www_pdf_url = "http://www.syverson.org/entropist-final.pdf",
   publisher = {Springer-Verlag, LNCS 7028},
   www_tags={selected},


### PR DESCRIPTION
the 'traffic' reference in the "Why i am not an entropist" listing makes bibliogra.py fail, david suggested to remove it.

```
Traceback (most recent call last):
  File "../bibliograpy/bibliogra.py", line 519, in <module>
    sys.exit(main(args.OUTPUT_DIR, args.file_name, args.header, args.footer))
  File "../bibliograpy/bibliogra.py", line 470, in main
    bibdata = parser.parse_file(file_name)
  File "/usr/lib/python2.7/dist-packages/pybtex/database/input/__init__.py", line 51, in parse_file
    self.parse_stream(f)
  File "/usr/lib/python2.7/dist-packages/pybtex/database/input/bibtex.py", line 365, in parse_stream
    for entry in entry_iterator:
  File "/usr/lib/python2.7/dist-packages/pybtex/database/input/bibtex.py", line 178, in parse_bibliography
    self.handle_error(error)
  File "/usr/lib/python2.7/dist-packages/pybtex/database/input/bibtex.py", line 350, in handle_error
    report_error(error)
  File "/usr/lib/python2.7/dist-packages/pybtex/errors.py", line 78, in report_error
    raise exception
pybtex.database.input.bibtex.UndefinedMacro: traffic
```